### PR TITLE
Update PCF CV: add Kubernetes cluster (Headlamp, Portainer, Homepage)

### DIFF
--- a/cv.md
+++ b/cv.md
@@ -12,7 +12,7 @@ permalink: /index.html
 - Senior Build Engineer contractor
 - *2023-2024*: Maintained pipelines with **Jenkins** + **Groovy** and started implementing Epic Games' **BuildGraph** to simplify **Unreal** compilation
 - *2024-2025*: Owner of Epic Games' **Horde** build system used internally
-- *2026 - Now*: **Perforce** admin, **Swarm** admin, **Ansible** deployment, **Docker**, **Robomerge**, and every kind of automation
+- *2026 - Now*: **Perforce** admin, **Swarm** admin, **Ansible** deployment, **Docker**, **Kubernetes** cluster with **Headlamp**, **Portainer**, and **Homepage**, **Robomerge**, and every kind of automation
 
 ### NHB Consulting SEZC - 2023 August to Now
 


### PR DESCRIPTION
### Motivation
- Reflect recent hands-on experience managing a Kubernetes cluster and its web tooling in the People Can Fly (PCF) CV section.

### Description
- Edited `cv.md` to update the People Can Fly entry by replacing the 2026 line to include `Kubernetes` cluster with `Headlamp`, `Portainer`, and `Homepage`.

### Testing
- Ran `git diff --check` with no issues and attempted `jekyll build` which failed because `jekyll: command not found` in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a243b8cbd408333b8b3043ae8c0f19b)